### PR TITLE
Update .travis.yml with xvfb service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,11 @@ install:
 - pip install git+https://github.com/lbl-camera/Xi-cam.plugins.git
 - pip install git+https://github.com/lbl-camera/Xi-cam.gui.git
 - pip install .[pyqt5,docs,tests]
+services:
+- xvfb
 script:
 - pip install pylint
 - 'pylint xicam --errors-only || :'
-- sh -e /etc/init.d/xvfb start
 - sleep 3
 - 'pytest . || :'
 - pip install -e .[dev]


### PR DESCRIPTION
Looks like the default travis build dist changed from trusty to xenial.

See [documentation regarding xvfb](https://docs.travis-ci.com/user/gui-and-headless-browsers/)